### PR TITLE
Setup base url for website

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ bundler exec jekyll serve
 To build the website as a static website use the command
 ```bash
 bundler exec jekyll build
-# Will output website to ./_build
+# Will output website to ./_site
 ```

--- a/_config.yml
+++ b/_config.yml
@@ -22,8 +22,8 @@ title: Interview prep
 email: nick.dmalt@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
   Interview prep website for Satya's Squad[rilateral]
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "/InterviewPrep"
+url: "https://nicholas-maltbie.github.io/InterviewPrep"
 github_username:  nicholas-maltbie
 
 # Build settings


### PR DESCRIPTION
# Description

Fixed website to use proper baseurl of `/InterviewPrep` as the normal base url is taken up by my personal blog. 

# Checklist

- [x] My code follows the style of the rest of this project
- [x] I have have looked over my additions to ensure they are correct
- [x] I have tested and ensured that the code works on my local browser
